### PR TITLE
Suitedev 14949 new intialization hook for consumers

### DIFF
--- a/src/consumers/batch-consumer.js
+++ b/src/consumers/batch-consumer.js
@@ -9,6 +9,7 @@ class RabbitMqBatchConsumer {
     this._logger = getLogger(configuration.logger);
     this._channel = configuration.channel;
     this._connectionType = configuration.connectionType || 'default';
+    this._onChannelEstablished = configuration.onChannelEstablished || (async () => Promise.resolve());
     this._batchTimeout = configuration.batchTimeout || 1000;
     this._batchSize = configuration.batchSize || 1024;
     this._onMessages = configuration.onMessages;
@@ -31,6 +32,7 @@ class RabbitMqBatchConsumer {
   async process() {
     try {
       await this._setupRabbitMqChannel();
+      await this._onChannelEstablished(this._rabbitMqChannel);
       this._consumer = await this._rabbitMqChannel.consume(this._channel, message => {
         this._inProgress++;
         const groupBy = message.properties.headers.groupBy;

--- a/src/consumers/batch-consumer.spec.js
+++ b/src/consumers/batch-consumer.spec.js
@@ -73,6 +73,17 @@ describe('RabbitMQ Batch Consumer', function() {
     expect(rabbitMqSpy).have.been.calledWith(amqpConfig, channelName, 'special');
   });
 
+  it('should call onChannelEstablished with channel', async function() {
+    stubRabbitMq();
+    const options = {
+      onChannelEstablished: sandbox.spy()
+    };
+    await createConsumer(options);
+
+    expect(options.onChannelEstablished).have.been.calledOnce;
+  });
+
+
   it('should call onMessages with batched messages', async function() {
     const message1 = createMessage({ content: '{"foo":"bar"}' });
     const message2 = createMessage({ content: '{"abc":"123"}' });

--- a/src/consumers/consumer.js
+++ b/src/consumers/consumer.js
@@ -9,6 +9,7 @@ class RabbitMqConsumer {
     this._logger = getLogger(configuration.logger);
     this._channel = configuration.channel;
     this._connectionType = configuration.connectionType || 'default';
+    this._onChannelEstablished = configuration.onChannelEstablished || (async () => Promise.resolve());
     this._onMessage = configuration.onMessage;
     this._retryTime = configuration.retryTime || 60000;
     this._prefetchCount = configuration.prefetchCount || parseInt(process.env.PREFETCH_COUNT, 10) || 1;
@@ -27,6 +28,7 @@ class RabbitMqConsumer {
       const rabbitMq = await RabbitMq.create(this._amqpConfig, this._channel, this._connectionType, this._queueOptions);
       const channel = rabbitMq.getChannel();
       await channel.prefetch(this._prefetchCount);
+      await this._onChannelEstablished(channel);
 
       channel.on('error', function(err) {
         logger.fromError('[AMQP] Channel error', err);

--- a/src/consumers/consumer.spec.js
+++ b/src/consumers/consumer.spec.js
@@ -85,6 +85,19 @@ describe('RabbitMQ Consumer', function() {
     expect(rabbitMqStub).have.been.calledWith(amqpConfig, channelName);
   });
 
+  it('should call onChannelEstablished with channel', async function() {
+    const options = {
+      logger: loggerName,
+      channel: channelName,
+      onChannelEstablished: sandbox.spy()
+    };
+
+    const rabbitMQConsumer = RabbitMQConsumer.create(amqpConfig, options);
+    await rabbitMQConsumer.process();
+
+    expect(options.onChannelEstablished).have.been.calledOnce;
+  });
+
   it('should not retry when message is not parsable as JSON', async function() {
     const message = { content: Buffer.from('Not a JSON') };
     const configuration = {


### PR DESCRIPTION
Allow consumers to have a special initialization hook to retrieve the channel and do any extra exchange asserts or exchange bindings.

Relates to: SUITEDEV-14949